### PR TITLE
Fix trailing new line issue for multiline strings

### DIFF
--- a/src/string.jl
+++ b/src/string.jl
@@ -43,7 +43,7 @@ function test_reference_string(file::File, actual::AbstractArray{<:AbstractStrin
     path = file.filename
     dir, filename = splitdir(path)
     try
-        reference = replace.(readlines(path), ["\n"], [""])
+        reference = split(readstring(path), "\n")
         try
             @assert reference == actual # to throw error
             @test true # to increase test counter if reached

--- a/test/references/string5.txt
+++ b/test/references/string5.txt
@@ -1,0 +1,2 @@
+This is a
+multiline string that does not end with a new line.

--- a/test/references/string6.txt
+++ b/test/references/string6.txt
@@ -1,0 +1,2 @@
+    This on the other hand is a
+    multiline string that does indeed end with a new line.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,9 @@
-using ImageInTerminal, Images, TestImages, Base.Test, ColorTypes, FixedPointNumbers
+using Base.Test, ImageInTerminal, Images, TestImages,  ColorTypes, FixedPointNumbers
 
 # check for ambiguities
 refambs = detect_ambiguities(ImageInTerminal, Base, Core)
 using ReferenceTests
-ambs = detect_ambiguities(ReferenceTests, ImageInTerminal, Base, Core)
+ambs = detect_ambiguities(ReferenceTests, ImageInTerminal, Base, Core)|
 @test length(setdiff(ambs, refambs)) == 0
 
 # load/create some example images
@@ -40,6 +40,16 @@ end
     @test_reference "references/string2.txt" @io2str show(IOContext(::IO, limit=true, displaysize=(5,5)), A)
     @test_reference "references/string3.txt" 1337
     @test_reference "references/string4.txt" @io2str show(::IO, MIME"text/plain"(), Int64.(collect(1:5)))
+
+    @test_reference "references/string5.txt" """
+        This is a
+        multiline string that does not end with a new line."""
+
+    @test_reference "references/string6.txt" """
+        This on the other hand is a
+        multiline string that does indeed end with a new line.
+    """
+
     @test_throws ErrorException @test_reference "references/string1.txt" "intentionally wrong to check that this message prints"
     @test_throws ErrorException @test_reference "references/wrong.txt" "intentional error to check that this message prints"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Base.Test, ImageInTerminal, Images, TestImages,  ColorTypes, FixedPointNum
 # check for ambiguities
 refambs = detect_ambiguities(ImageInTerminal, Base, Core)
 using ReferenceTests
-ambs = detect_ambiguities(ReferenceTests, ImageInTerminal, Base, Core)|
+ambs = detect_ambiguities(ReferenceTests, ImageInTerminal, Base, Core)
 @test length(setdiff(ambs, refambs)) == 0
 
 # load/create some example images


### PR DESCRIPTION
It is a confusingly documented feature of `readlines` that it doesn't trim trailing newlines,
except if that trailing newline is the last character of a file.

Seems like easiest is to just read it all and split it.