### PR TITLE
Just warn on regeneration (not error)

### DIFF
--- a/src/string.jl
+++ b/src/string.jl
@@ -61,7 +61,7 @@ function test_reference_string(file::File, actual::AbstractArray{<:AbstractStrin
                 if answer == 'y'
                     write(path, join(actual, "\n"))
                 end
-                error("Please run the tests again for any changes to take effect")
+                warn("Please run the tests again for any changes to take effect")
             else
                 error("You need to run the tests interactively with 'include(\"test/runtests.jl\")' to update reference images")
             end

--- a/src/string.jl
+++ b/src/string.jl
@@ -60,8 +60,10 @@ function test_reference_string(file::File, actual::AbstractArray{<:AbstractStrin
                 answer = first(readline())
                 if answer == 'y'
                     write(path, join(actual, "\n"))
+                    warn("Please run the tests again for any changes to take effect")
+                else
+                    @test false
                 end
-                warn("Please run the tests again for any changes to take effect")
             else
                 error("You need to run the tests interactively with 'include(\"test/runtests.jl\")' to update reference images")
             end


### PR DESCRIPTION
Closes #3 

I needed to regenerate like 30 reference tests or something.
This made it not utter suffering.

Though having some kind of setting (maybe an environment variables) for "Replace all nonmatching",
might be good.