### PR TITLE
More robut user input handling

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -87,9 +87,7 @@ function _test_reference(equiv, rendermode, file::File, actual::T) where T
             println("Test for \"$filename\" failed.")
             render(rendermode, reference, actual)
             if isinteractive()
-                print("Replace reference with actual result (path: $path)? [y/n] ")
-                answer = first(readline())
-                if answer == 'y'
+                if input_bool("Replace reference with actual result (path: $path)?")
                     savefile(file, actual)
                     warn("Please run the tests again for any changes to take effect")
                 else
@@ -107,9 +105,7 @@ function _test_reference(equiv, rendermode, file::File, actual::T) where T
             println("Reference file for \"$filename\" does not exist.")
             render(rendermode, actual)
             if isinteractive()
-                print("Create reference file with above content (path: $path)? [y/n] ")
-                answer = first(readline())
-                if answer == 'y'
+                if input_bool("Create reference file with above content (path: $path)?")
                     mkpath(dir)
                     savefile(file, actual)
                     warn("Please run the tests again for any changes to take effect")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -87,3 +87,21 @@ function withcolor(fun)
         eval(Base, :(have_color = $old_color))
     end
 end
+
+# --------------------------------------------------------------------
+
+function input_bool(prompt)
+    while true
+        println(prompt, " [y/n]")
+        response = readline()
+        length(response)==0 && continue
+        reply = lowercase(first(strip(response)))
+        if reply == 'y'
+            return true
+        elseif reply =='n'
+            return false
+        end
+        # Otherwise loop and repeat the prompt
+    end
+end
+


### PR DESCRIPTION
This makes the getting of user input more robut.
Either they say <kbd>y</kbd>  or <kbd>n</kbd>
Or something close enough.
Otherwise they get reprompted.

This helps people like me who just kind of vaguely fail at the keyboard, and mash all the keys.

In particular this stops errors being thrown on if they press <kbd>Enter</kbd> without entering  any text
