### PR TITLE
[WIP] Make Images a soft dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ to be used alongside `Base.Test`._
 |:------------------:|:---------------------:|:-----------------:|
 | [![License](http://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat)](LICENSE.md) [![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://evizero.github.io/ReferenceTests.jl/latest) | [![Pkg Eval 0.6](http://pkg.julialang.org/badges/ReferenceTests_0.6.svg)](http://pkg.julialang.org/?pkg=ReferenceTests) [![Pkg Eval 0.7](http://pkg.julialang.org/badges/ReferenceTests_0.7.svg)](http://pkg.julialang.org/?pkg=ReferenceTests) | [![Travis](https://travis-ci.org/Evizero/ReferenceTests.jl.svg?branch=master)](https://travis-ci.org/Evizero/ReferenceTests.jl) [![AppVeyor](https://ci.appveyor.com/api/projects/status/fle0090403pdgnxi?svg=true)](https://ci.appveyor.com/project/Evizero/referencetests-jl) [![Coverage Status](https://coveralls.io/repos/Evizero/ReferenceTests.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/Evizero/ReferenceTests.jl?branch=master) |
 
-**Note:** This package is still in early development. So far most
+**Note:** This package is development. So far most
 attention went into comparing images and strings. The `FileIO`
 fallbacks are thus yet not fully fleshed out and may change over
 time.
@@ -80,7 +80,9 @@ using ReferenceTests, TestImages
 Note that while a text-based storage of reference images can be
 convenient, proper image formats (e.g. `png`) are also supported
 by the package. Those, however, will require the proper `FileIO`
-backends to be installed.
+backends to be installed, and the *Images.jl* package to be 
+installed and loaded.
+(i.e. do `using Images; using ReferenceTests` for image support)
 
 Another special file extension is `sha256` which will cause the
 hash of the result of the given expression to be stored and

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,8 @@
 julia 0.6
-Images 0.6
 FileIO 0.4
+ImageCore 0.1.1
 ImageInTerminal 0.2
 ColorTypes 0.4
 DeepDiffs
 SHA
+Requires

--- a/src/ReferenceTests.jl
+++ b/src/ReferenceTests.jl
@@ -1,8 +1,9 @@
 module ReferenceTests
 
 using Base.Test
-using Images
+using Requires
 using FileIO
+using ImageCore
 using ImageInTerminal
 using ColorTypes
 using SHA

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -13,16 +13,18 @@ end
 # ---------------------------------
 # Image
 
-function test_reference(file::File, actual::AbstractArray{<:Colorant}; sigma=ones(length(indices(actual))), eps=0.01)
-    _test_reference(BeforeAfterImage(), file, actual) do reference, actual
-        try
-            Images.@test_approx_eq_sigma_eps(reference, actual, sigma, eps)
-            return true
-        catch err
-            if err isa ErrorException
-                return false
-            else
-                rethrow()
+@require Images begin
+    function test_reference(file::File, actual::AbstractArray{<:Colorant}; sigma=ones(length(indices(actual))), eps=0.01)
+        _test_reference(BeforeAfterImage(), file, actual) do reference, actual
+            try
+                Images.@test_approx_eq_sigma_eps(reference, actual, sigma, eps)
+                return true
+            catch err
+                if err isa ErrorException
+                    return false
+                else
+                    rethrow()
+                end
             end
         end
     end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -2,6 +2,7 @@ FixedPointNumbers 0.3
 TestImages
 DataFrames
 CSVFiles 0.3
+Images 0.6
 @windows ImageMagick
 @linux ImageMagick
 @osx QuartzImageIO


### PR DESCRIPTION
This passes tests but 
something seems to go wrong with the rendering

![screenshot showing that images are without color. ie are just grey boxes](https://user-images.githubusercontent.com/5127634/42130904-eb686974-7d25-11e8-87bd-6b76b615520d.png)


I'm also not sure how many dependencies it cuts.
Given ImageInTerminal.jl still depends on ImageTransformations.jl.
And ImageTransformations,jls [dependency list is huge](https://github.com/JuliaImages/ImageTransformations.jl/blob/master/REQUIRE).

This probably isn't worth doing,
since 0.7 makes install so much faster.