### PR TITLE
allow customizable RenderMode for txt

### DIFF
--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -1,13 +1,13 @@
 # --------------------------------------------------------------------
 # plain TXT
 
-function test_reference(file::File{format"TXT"}, actual)
-    _test_reference(Diff(), file, string(actual))
+function test_reference(file::File{format"TXT"}, actual; render = Diff())
+    _test_reference(render, file, string(actual))
 end
 
-function test_reference(file::File{format"TXT"}, actual::AbstractArray{<:AbstractString})
+function test_reference(file::File{format"TXT"}, actual::AbstractArray{<:AbstractString}; render = Diff())
     str = join(actual, '\n')
-    _test_reference(Diff(), file, str)
+    _test_reference(render, file, str)
 end
 
 # ---------------------------------
@@ -29,10 +29,10 @@ function test_reference(file::File, actual::AbstractArray{<:Colorant}; sigma=one
 end
 
 # Image as txt using ImageInTerminal
-function test_reference(file::File{format"TXT"}, actual::AbstractArray{<:Colorant}; size = (20,40))
+function test_reference(file::File{format"TXT"}, actual::AbstractArray{<:Colorant}; size = (20,40), render = BeforeAfterFull())
     strs = @withcolor ImageInTerminal.encodeimg(ImageInTerminal.SmallBlocks(), ImageInTerminal.TermColor256(), actual, size...)[1]
     str = join(strs,'\n')
-    _test_reference(BeforeAfterFull(), file, str)
+    _test_reference(render, file, str)
 end
 
 # --------------------------------------------------------------------

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,7 +28,7 @@ end
 io2str_impl(arg) = :(throw(ArgumentError("Invalid use of `@io2str` macro: The given argument `$($(string(arg)))` is not an expression.")))
 
 function io2str_impl(expr::Expr)
-    nvar = Symbol("#io#", randstring(4))
+    nvar = gensym("io")
     if replace_expr!(expr, :(::IO), nvar)
         esc(quote
             $nvar = Base.IOBuffer()

--- a/test/references/ansii.txt
+++ b/test/references/ansii.txt
@@ -1,0 +1,1 @@
+[34mthis should be blue[39m

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ if isinteractive()
     @info ("In interactive use, one should respond \"n\" when the program"
            * " offers to create or replace files associated with some tests.")
 else
-    @info ("Four tests should correctly report failure in the transcript"
+    @info ("Eight tests should correctly report failure in the transcript"
            * " (but not the test summary).")
 end
 # check for ambiguities
@@ -75,6 +75,19 @@ end
     #@test_throws MethodError @test_reference "references/fail.txt" rand(2,2)
     @test_reference "references/camera.txt" camera size=(5,10)
     @test_reference "references/lena.txt" lena
+end
+
+@testset "plain ansi string" begin
+    @test_reference(
+        "references/ansii.txt",
+        @io2str(printstyled(IOContext(::IO, :color=>true), "this should be blue", color=:blue)),
+        render = ReferenceTests.BeforeAfterFull()
+    )
+    @test_throws ErrorException @test_reference(
+        "references/ansii.txt",
+        @io2str(printstyled(IOContext(::IO, :color=>true), "this should be red", color=:red)),
+        render = ReferenceTests.BeforeAfterFull()
+    )
 end
 
 @testset "string as SHA" begin


### PR DESCRIPTION
This commit enables a user to provide a `mode` keyword to `@test_reference` for "txt" files, which overwrites the default `RenderMode`. This is useful if the text contains ANSII colors and should not be displayed as a `Diff`, but rather as a `BeforeAfter`.

This will allow convenient **testing for UnicodePlots ... thats right, its finally happening**.