### PR TITLE
[WIP] reduce package dependency (fixes #5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
+  - 1.1
   - nightly
 notifications:
   email: false
@@ -32,14 +32,10 @@ jobs:
       julia: 1.0
       os: linux
       script:
-        - julia -e 'import Pkg; Pkg.clone(pwd()); Pkg.build("ReferenceTests")'
         - julia -e 'import Pkg; ps=Pkg.PackageSpec(name="Documenter", version="0.19"); Pkg.add(ps); Pkg.pin(ps)'
         - julia -e 'import ReferenceTests; ENV["DOCUMENTER_DEBUG"] = "true"; include(joinpath("docs","make.jl"))'
 
-## uncomment the following lines to override the default test script
-script:
-    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia --check-bounds=yes --color=yes -e 'import Pkg; Pkg.clone(pwd()); Pkg.build("ReferenceTests"); Pkg.test("ReferenceTests"; coverage=true)';
+# use default script for test
 
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'

--- a/Project.toml
+++ b/Project.toml
@@ -7,9 +7,13 @@ version = "0.6.0"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 ColorTypes = ">= 0.4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,30 @@
+name = "ReferenceTests"
+uuid = "324d217c-45ce-50fc-942e-d289b448e8cf"
+authors = ["Christof Stocker <stocker.christof@gmail.com>", "Lyndon White <oxinabox@ucc.asn.au>"]
+version = "0.6.0"
+
+[deps]
+ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254"
+Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[compat]
+ColorTypes = ">= 0.4"
+FileIO = ">= 0.4"
+ImageInTerminal = ">= 0.3"
+Images = ">= 0.15"
+julia = ">= 1.0"
+
+[extras]
+CSVFiles = "5d742f6a-9f54-50ce-8119-2520741973ca"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
+
+[targets]
+test = ["CSVFiles", "DataFrames", "FixedPointNumbers", "ImageMagick", "TestImages", "Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,0 @@
-julia 0.7
-Images 0.15
-FileIO 0.4
-ImageInTerminal 0.3
-ColorTypes 0.4
-DeepDiffs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - julia_version: 0.7
   - julia_version: 1.0
+  - julia_version: 1.1
   - julia_version: latest
 
 platform:

--- a/src/ReferenceTests.jl
+++ b/src/ReferenceTests.jl
@@ -1,13 +1,12 @@
 module ReferenceTests
 
 using Test
-using Images
-using FileIO
-using ImageInTerminal
-using ColorTypes
-using SHA
-using DeepDiffs
 using Random
+using SHA
+
+using FileIO
+using DeepDiffs
+using Requires
 
 export
     @withcolor,
@@ -17,6 +16,19 @@ export
 include("utils.jl")
 include("test_reference.jl")
 include("core.jl")
-include("handlers.jl")
+
+# handlers with no heavy requirements
+include("handlers/general.jl")
+include("handlers/text.jl")
+
+function __init__()
+    # images type
+    @require ColorTypes="3da002f7-5984-5a60-b8a6-cbb66c0b333f" include("handlers/image.jl")
+    @require Colors="5ae59095-9a9b-59fe-a467-6f913c188581" include("handlers/image.jl")
+    @require ImageCore="a09fc81d-aa75-5fe9-8630-4744c3626534" include("handlers/image.jl")
+    @require ImageInTerminal="d8c32880-2388-543b-8c61-d9f865259254" include("handlers/image.jl")
+    @require Images="916415d5-f1e6-5110-898d-aaa5f9f070e0" include("handlers/image.jl")
+    @require TestImages="5e47fb64-e119-507b-a336-dd2b206d9990" include("handlers/image.jl")
+end
 
 end # module

--- a/src/handlers/general.jl
+++ b/src/handlers/general.jl
@@ -1,0 +1,11 @@
+# Fallback handlers
+function test_reference(file::File, actual)
+    if actual isa AbstractString
+        # we don't use dispatch for this as it is very ambiguous
+        # specialization will remove this conditional regardless
+
+        _test_reference(Diff(), file, actual)
+    else
+        _test_reference(BeforeAfterLimited(), file, actual)
+    end
+end

--- a/src/handlers/image.jl
+++ b/src/handlers/image.jl
@@ -1,17 +1,11 @@
-# --------------------------------------------------------------------
-# plain TXT
-
-function test_reference(file::File{format"TXT"}, actual; render = Diff())
-    _test_reference(render, file, string(actual))
-end
-
-function test_reference(file::File{format"TXT"}, actual::AbstractArray{<:AbstractString}; render = Diff())
-    str = join(actual, '\n')
-    _test_reference(render, file, str)
-end
+using Images
+using ColorTypes
+using ImageCore
+using ImageInTerminal
 
 # ---------------------------------
 # Image
+# @require Images # TODO: Images is a large dependency
 
 function test_reference(file::File, actual::AbstractArray{<:Colorant}; sigma=ones(length(axes(actual))), eps=0.01)
     _test_reference(BeforeAfterImage(), file, actual) do reference, actual
@@ -28,41 +22,18 @@ function test_reference(file::File, actual::AbstractArray{<:Colorant}; sigma=one
     end
 end
 
+# ---------------------------------
 # Image as txt using ImageInTerminal
+# @require ImageInTerminal
+
 function test_reference(file::File{format"TXT"}, actual::AbstractArray{<:Colorant}; size = (20,40), render = BeforeAfterFull())
     strs = @withcolor ImageInTerminal.encodeimg(ImageInTerminal.SmallBlocks(), ImageInTerminal.TermColor256(), actual, size...)[1]
     str = join(strs,'\n')
     _test_reference(render, file, str)
 end
 
-# --------------------------------------------------------------------
-# SHA as string
-
-function test_reference(file::File{format"SHA256"}, actual)
-    test_reference(file, string(actual))
-end
-
-function test_reference(file::File{format"SHA256"}, actual::Union{AbstractString,Vector{UInt8}})
-    str = bytes2hex(sha256(actual))
-    _test_reference(BeforeAfterFull(), file, str)
-end
-
 function test_reference(file::File{format"SHA256"}, actual::AbstractArray{<:Colorant})
     size_str = bytes2hex(sha256(reinterpret(UInt8,[map(Int64,size(actual))...])))
     img_str = bytes2hex(sha256(reinterpret(UInt8,vec(rawview(channelview(actual))))))
     _test_reference(BeforeAfterFull(), file, size_str * img_str)
-end
-
-# --------------------------------------------------------------------
-
-# Fallback
-function test_reference(file::File, actual)
-    if actual isa AbstractString
-        # we don't use dispatch for this as it is very ambiguous
-        # specialization will remove this conditional regardless
-
-        _test_reference(Diff(), file, actual)
-    else
-        _test_reference(BeforeAfterLimited(), file, actual)
-    end
 end

--- a/src/handlers/text.jl
+++ b/src/handlers/text.jl
@@ -1,0 +1,23 @@
+# --------------------------------------------------------------------
+# plain TXT
+
+function test_reference(file::File{format"TXT"}, actual; render = Diff())
+    _test_reference(render, file, string(actual))
+end
+
+function test_reference(file::File{format"TXT"}, actual::AbstractArray{<:AbstractString}; render = Diff())
+    str = join(actual, '\n')
+    _test_reference(render, file, str)
+end
+
+# --------------------------------------------------------------------
+# SHA as string
+
+function test_reference(file::File{format"SHA256"}, actual)
+    test_reference(file, string(actual))
+end
+
+function test_reference(file::File{format"SHA256"}, actual::Union{AbstractString,Vector{UInt8}})
+    str = bytes2hex(sha256(actual))
+    _test_reference(BeforeAfterFull(), file, str)
+end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,5 +1,0 @@
-FixedPointNumbers 0.3
-TestImages 0.4
-DataFrames
-CSVFiles 0.3
-ImageMagick 0.7


### PR DESCRIPTION
Two things are done here:

- [x] upgrade to the new registrator and drop 0.7 compatibility
- [x] reduce package dependency #5 #11 

After this PR you need to:

* install https://github.com/JuliaComputing/Registrator.jl
* [optional] install https://github.com/christopher-dG/tag-bot
* bump a version