### PR TITLE
move Test from [extras] to [deps]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReferenceTests"
 uuid = "324d217c-45ce-50fc-942e-d289b448e8cf"
 authors = ["Christof Stocker <stocker.christof@gmail.com>", "Lyndon White <oxinabox@ucc.asn.au>"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/Project.toml
+++ b/Project.toml
@@ -27,4 +27,4 @@ ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["CSVFiles", "DataFrames", "FixedPointNumbers", "ImageMagick", "TestImages", "Test"]
+test = ["CSVFiles", "DataFrames", "FixedPointNumbers", "ImageMagick", "TestImages"]

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 ColorTypes = ">= 0.4"
@@ -23,7 +24,6 @@ CSVFiles = "5d742f6a-9f54-50ce-8119-2520741973ca"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]


### PR DESCRIPTION
This fixes the following warning
```julia
┌ Warning: Package ReferenceTests does not have Test in its dependencies:
│ - If you have ReferenceTests checked out for development and have
│   added Test as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with ReferenceTests
└ Loading Test into ReferenceTests from project dependency, future warnings for ReferenceTests are suppressed.
```