### PR TITLE
enhance `test_reference` API and support Number type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+/Manifest.toml

--- a/src/ReferenceTests.jl
+++ b/src/ReferenceTests.jl
@@ -18,5 +18,6 @@ include("utils.jl")
 include("test_reference.jl")
 include("core.jl")
 include("handlers.jl")
+include("equality_metrics.jl")
 
 end # module

--- a/src/core.jl
+++ b/src/core.jl
@@ -55,7 +55,11 @@ function loadfile(T, file::File)
 end
 
 function loadfile(T, file::TextFile)
-    read(file.filename,String)
+    read(file.filename, String)
+end
+
+function loadfile(::Type{<:Number}, file::File{format"TXT"})
+    parse(Float64, loadfile(String, file))
 end
 
 function savefile(file::File, content)
@@ -71,10 +75,6 @@ end
 # Final function
 # all other functions should hit one of this eventually
 # Which handles the actual testing and user prompting
-
-function _test_reference(rendermode, file::File, actual)
-    _test_reference(isequal, rendermode, file, actual)
-end
 
 function _test_reference(equiv, rendermode, file::File, actual::T) where T
     path = file.filename

--- a/src/equality_metrics.jl
+++ b/src/equality_metrics.jl
@@ -1,0 +1,12 @@
+function default_image_equality(reference, actual)
+    try
+        Images.@test_approx_eq_sigma_eps(reference, actual, ones(length(axes(actual))), 0.01)
+        return true
+    catch err
+        if err isa ErrorException
+            return false
+        else
+            rethrow()
+        end
+    end
+end

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -1,68 +1,65 @@
 # --------------------------------------------------------------------
 # plain TXT
 
-function test_reference(file::File{format"TXT"}, actual; render = Diff())
-    _test_reference(render, file, string(actual))
+function test_reference(file::File{format"TXT"}, actual; by = isequal, render = Diff())
+    _test_reference(by, render, file, string(actual))
 end
 
-function test_reference(file::File{format"TXT"}, actual::AbstractArray{<:AbstractString}; render = Diff())
+function test_reference(file::File{format"TXT"}, actual::Number; by = isequal, render = BeforeAfterFull())
+    _test_reference(by, render, file, actual)
+end
+
+function test_reference(file::File{format"TXT"}, actual::AbstractArray{<:AbstractString}; by = isequal, render = Diff())
     str = join(actual, '\n')
-    _test_reference(render, file, str)
+    _test_reference(by, render, file, str)
 end
 
 # ---------------------------------
 # Image
 
-function test_reference(file::File, actual::AbstractArray{<:Colorant}; sigma=ones(length(axes(actual))), eps=0.01)
-    _test_reference(BeforeAfterImage(), file, actual) do reference, actual
-        try
-            Images.@test_approx_eq_sigma_eps(reference, actual, sigma, eps)
-            return true
-        catch err
-            if err isa ErrorException
-                return false
-            else
-                rethrow()
-            end
-        end
-    end
+function test_reference(file::File, actual::AbstractArray{<:Colorant}; by = default_image_equality, render = BeforeAfterImage())
+    _test_reference(by, render, file, actual)
 end
 
 # Image as txt using ImageInTerminal
-function test_reference(file::File{format"TXT"}, actual::AbstractArray{<:Colorant}; size = (20,40), render = BeforeAfterFull())
+function test_reference(file::File{format"TXT"}, actual::AbstractArray{<:Colorant}; size = (20,40), by = isequal, render = BeforeAfterFull())
     strs = @withcolor ImageInTerminal.encodeimg(ImageInTerminal.SmallBlocks(), ImageInTerminal.TermColor256(), actual, size...)[1]
     str = join(strs,'\n')
-    _test_reference(render, file, str)
+    _test_reference(by, render, file, str)
 end
 
 # --------------------------------------------------------------------
 # SHA as string
 
-function test_reference(file::File{format"SHA256"}, actual)
-    test_reference(file, string(actual))
+function test_reference(file::File{format"SHA256"}, actual; by = nothing, render = BeforeAfterFull())
+    test_reference(file, string(actual); render = render)
 end
 
-function test_reference(file::File{format"SHA256"}, actual::Union{AbstractString,Vector{UInt8}})
+function test_reference(file::File{format"SHA256"}, actual::Union{AbstractString,Vector{UInt8}}; by = nothing, render = BeforeAfterFull())
     str = bytes2hex(sha256(actual))
-    _test_reference(BeforeAfterFull(), file, str)
+    _test_reference(isequal, render, file, str)
 end
 
-function test_reference(file::File{format"SHA256"}, actual::AbstractArray{<:Colorant})
+function test_reference(file::File{format"SHA256"}, actual::AbstractArray{<:Colorant}; by = nothing, render = BeforeAfterFull())
     size_str = bytes2hex(sha256(reinterpret(UInt8,[map(Int64,size(actual))...])))
     img_str = bytes2hex(sha256(reinterpret(UInt8,vec(rawview(channelview(actual))))))
-    _test_reference(BeforeAfterFull(), file, size_str * img_str)
+    _test_reference(isequal, render, file, size_str * img_str)
 end
 
 # --------------------------------------------------------------------
 
 # Fallback
-function test_reference(file::File, actual)
-    if actual isa AbstractString
-        # we don't use dispatch for this as it is very ambiguous
-        # specialization will remove this conditional regardless
-
-        _test_reference(Diff(), file, actual)
+function test_reference(file::File, actual; by = isequal, render = nothing)
+    if !(render === nothing)
+        _test_reference(by, render, file, actual)
     else
-        _test_reference(BeforeAfterLimited(), file, actual)
+        if actual isa AbstractString
+            # we don't use dispatch for this as it is very ambiguous
+            # specialization will remove this conditional regardless
+
+            _test_reference(by, Diff(), file, actual)
+        else
+            _test_reference(by, BeforeAfterLimited(), file, actual)
+        end
     end
 end

--- a/src/test_reference.jl
+++ b/src/test_reference.jl
@@ -1,37 +1,56 @@
 """
-    @test_reference filename ex [kw...]
+    @test_reference filename expr [by] [kw...]
 
-Tests that the expression `ex` evaluates to the same result as
-stored in the given reference file, which is denoted by the
-string `filename`. Executing the code in an interactive julia
-session will trigger an interactive dialog if results don't
-match. This dialog allows the user to create and/or update the
-reference files.
+Tests that the expression `expr` with reference `filename` using
+equality test strategy `by`.
 
-The given string `filename` is assumed to be the relative path to
-the file that contains the macro invocation. This likely means
-that the path `filename` is relative to the `test/` folder of
-your package.
+The pipeline of `test_reference` is:
+
+1. preprocess `expr`
+2. read and preprocess `filename`
+3. compare the results using `by`
+4. if test fails in an interactive session (e.g, `include(test/runtests.jl)`), an interactive dialog will be trigered.
+
+Arguments:
+
+* `filename::String`: _relative_ path to the file that contains the macro invocation.
+* `expr`: the actual content used to compare.
+* `by`: the equality test function. By default it is `isequal` if not explicitly stated.
+
+# Types
 
 The file-extension of `filename`, as well as the type of the
-result of evaluating `ex`, determine how the actual value is
-compared to the reference value. The default implementation will
-do a simple equality check with the result of `FileIO.load`. This
-means that it is the user's responsibility to have the required
-IO package installed.
+result of evaluating `expr`, determine how contents are processed and
+compared. The contents is treated as:
 
-Colorant arrays (i.e.) receive special treatment. If the
-extension of `filename` is `txt` then the package
-`ImageInTerminal` will be used to create a string based cure
-approximation of the image. This will have low storage
-requirements and also allows to view the reference file in a
-simple terminal using `cat`.
+* Images when `expr` is an image type, i.e., `AbstractArray{<:Colorant}`;
+* SHA256 when `filename` endswith `*.sha256`;
+* Text as a fallback.
 
-Another special file extension is `sha256` which will cause the
-hash of the result of `ex` to be stored and compared as plain
-text. This is useful for a convenient low-storage way of making
-sure that the return value doesn't change for selected test
-cases.
+## Images
+
+Images are compared _approximately_ using a different `by` to ignore most encoding
+and decoding errors. The default value is `Images.@test_approx_eq_sigma_eps`.
+
+The file can be either common image files (e.g., `*.png`), which are handled by
+`FileIO`, or text-coded `*.txt` files, which is handled by `ImageInTerminal`.
+Text-coded image has less storage requirements and also allows to view the
+reference file in a simple terminal using `cat`.
+
+## SHA256
+
+The hash of the `expr` and content of `filename` are compared.
+
+!!! tip
+
+    This is useful for a convenient low-storage way of making
+    sure that the return value doesn't change for selected test
+    cases.
+
+## Fallback
+
+Simply test the equality of `expr` and the contents of `filename` without any
+preprocessing.
 
 # Examples
 
@@ -45,6 +64,12 @@ cases.
 # Images can also be stored as hash. Note however that this
 # can only check for equality (no tolerance possible)
 @test_reference "references/camera.sha256" testimage("cameraman")
+
+# test images using ImageQualityIndexes.PSNR
+@test_reference "references/camera.png" testimage("cameraman") by=(x,y)->psnr(x,y)>25
+
+# test number with absolute tolerance 10
+@test_reference "references/string3.txt" 1338 by=(ref, x)->isapprox(ref, x; atol=10)
 ```
 """
 macro test_reference(reference, actual, kws...)

--- a/src/test_reference.jl
+++ b/src/test_reference.jl
@@ -77,7 +77,8 @@ macro test_reference(reference, actual, kws...)
     expr = :(test_reference(abspath(joinpath($dir, $(esc(reference)))), $(esc(actual))))
     for kw in kws
         (kw isa Expr && kw.head == :(=)) || error("invalid signature for @test_reference")
-        push!(expr.args, Expr(:kw, kw.args...))
+        k, v = kw.args
+        push!(expr.args, Expr(:kw, k, esc(v)))
     end
     expr
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -104,4 +104,3 @@ function input_bool(prompt)
         # Otherwise loop and repeat the prompt
     end
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,6 +53,7 @@ end
     A = ones(30,30)
     @test_reference "references/string2.txt" @io2str show(IOContext(::IO, :limit=>true, :displaysize=>(5,5)), A)
     @test_reference "references/string3.txt" 1337
+    @test_reference "references/string3.txt" 1338 by=(ref, x)->isapprox(ref, x; atol=10)
     @test_reference "references/string4.txt" @io2str show(::IO, MIME"text/plain"(), Int64.(collect(1:5)))
 
     @test_reference "references/string5.txt" """


### PR DESCRIPTION
Changes:

* keep two keyword arguments: `render` and `test`(new)
* add util `number_test` to compare numbers (closes #25 )
* *heavily* rewrite the docstring ⚠️

By exposing `test` to users, they're free to define other comparison methods and pass it to `@test_reference`. For example, 

```julia
# add an absolute tolerance for numbers comparison
@test_reference "references/string3.txt" 1338 test=number_test(10)

# use PSNR for images comparison
@test_reference "references/camera.png" testimage("cameraman") test=(x,y)->psnr(x,y)>25
```

RFC:

* `psnr` comes from [`ImageQualityIndexes`](https://github.com/JuliaImages/ImageQualityIndexes.jl), which is lighter than `Images`. Shall we replace `Images.@test_approx_eq_sigma_eps` with this to remove the direct dependency on `Images`?