### PR TITLE
reduce pakcage dependencies and introduce psnr_equality

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReferenceTests"
 uuid = "324d217c-45ce-50fc-942e-d289b448e8cf"
 authors = ["Christof Stocker <stocker.christof@gmail.com>", "Lyndon White <oxinabox@ucc.asn.au>"]
-version = "0.7.0"
+version = "0.8.0"
 
 [deps]
 DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"

--- a/Project.toml
+++ b/Project.toml
@@ -14,10 +14,10 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-FileIO = ">= 0.4"
-ImageCore = ">= 0.8.1"
-ImageInTerminal = ">= 0.3"
-julia = ">= 1"
+FileIO = "1"
+ImageCore = "0.8.1"
+ImageInTerminal = "0.3, 0.4"
+julia = "1"
 
 [extras]
 CSVFiles = "5d742f6a-9f54-50ce-8119-2520741973ca"

--- a/Project.toml
+++ b/Project.toml
@@ -4,28 +4,27 @@ authors = ["Christof Stocker <stocker.christof@gmail.com>", "Lyndon White <oxina
 version = "0.7.0"
 
 [deps]
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
+Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254"
-Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-ColorTypes = ">= 0.4"
 FileIO = ">= 0.4"
+ImageCore = ">= 0.8.1"
 ImageInTerminal = ">= 0.3"
-Images = ">= 0.15"
-julia = ">= 1.0"
+julia = ">= 1"
 
 [extras]
 CSVFiles = "5d742f6a-9f54-50ce-8119-2520741973ca"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
+ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["CSVFiles", "DataFrames", "FixedPointNumbers", "ImageMagick", "TestImages"]
+test = ["CSVFiles", "DataFrames", "ImageMagick", "ImageTransformations", "TestImages"]

--- a/src/ReferenceTests.jl
+++ b/src/ReferenceTests.jl
@@ -1,10 +1,10 @@
 module ReferenceTests
 
 using Test
-using Images
+using ImageCore
+using Distances
 using FileIO
 using ImageInTerminal
-using ColorTypes
 using SHA
 using DeepDiffs
 using Random
@@ -12,7 +12,8 @@ using Random
 export
     @withcolor,
     @io2str,
-    @test_reference
+    @test_reference,
+    psnr_equality
 
 include("utils.jl")
 include("test_reference.jl")

--- a/src/equality_metrics.jl
+++ b/src/equality_metrics.jl
@@ -1,12 +1,40 @@
-function default_image_equality(reference, actual)
-    try
-        Images.@test_approx_eq_sigma_eps(reference, actual, ones(length(axes(actual))), 0.01)
-        return true
-    catch err
-        if err isa ErrorException
-            return false
+# ---------------------------------
+# Image
+
+default_image_equality(reference, actual) = psnr_equality()(reference, actual)
+
+"""
+    psnr_equality(threshold=25) -> f
+
+Generates an equality comparison function in terms of Peak Signal-to-Noise Ratio (PSNR).
+
+The return function `f` accepts two images `reference` and `actual` as its inputs;
+`f(reference, actual) == true` if `psnr(reference, actual) >= threshold`.
+
+This function is useful for image comparison, for example:
+
+```julia
+@test_reference "references/camera.png" testimage("cameraman") by=psnr_equality(20)
+```
+"""
+function psnr_equality(threshold=25)
+    function (ref, x)
+        rst = _psnr(ref, x)
+        if rst >= threshold
+            return true
         else
-            rethrow()
+            @warn("test fails because PSNR $rst < $threshold")
+            return false
         end
     end
 end
+
+# a simplified PSNR is sufficient since we only use it to approximately compare two images
+_psnr(ref::AbstractArray{<:Color3}, x::AbstractArray{<:Color3}) =
+    _psnr(channelview(RGB.(ref)), channelview(RGB.(x)), 1.0)
+
+_psnr(ref::AbstractArray{<:AbstractGray}, x::AbstractArray{<:AbstractGray}) =
+    _psnr(channelview(ref), channelview(x), 1.0)
+
+_psnr(ref::AbstractArray{<:Real}, x::AbstractArray{<:Real}, peakval::Real) =
+    20log10(peakval) - 10log10(euclidean(ref, x))

--- a/src/test_reference.jl
+++ b/src/test_reference.jl
@@ -30,7 +30,7 @@ compared. The contents is treated as:
 ## Images
 
 Images are compared _approximately_ using a different `by` to ignore most encoding
-and decoding errors. The default value is `Images.@test_approx_eq_sigma_eps`.
+and decoding errors. The default function is generated from [`psnr_equality`](@ref).
 
 The file can be either common image files (e.g., `*.png`), which are handled by
 `FileIO`, or text-coded `*.txt` files, which is handled by `ImageInTerminal`.
@@ -65,8 +65,8 @@ preprocessing.
 # can only check for equality (no tolerance possible)
 @test_reference "references/camera.sha256" testimage("cameraman")
 
-# test images using ImageQualityIndexes.PSNR
-@test_reference "references/camera.png" testimage("cameraman") by=(x,y)->psnr(x,y)>25
+# test images with custom psnr threshold
+@test_reference "references/camera.png" testimage("cameraman") by=psnr_equality(20)
 
 # test number with absolute tolerance 10
 @test_reference "references/string3.txt" 1338 by=(ref, x)->isapprox(ref, x; atol=10)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using Test
-using ImageMagick
-using ImageInTerminal, Images, TestImages,  ColorTypes, FixedPointNumbers
+using ImageInTerminal, TestImages, ImageCore, ImageTransformations
 using Random
 
 if isinteractive()
@@ -110,6 +109,7 @@ end
 
 @testset "images as PNG" begin
     @test_reference "references/camera.png" imresize(camera, (64,64))
+    @test_reference "references/camera.png" imresize(camera, (64,64)) by=psnr_equality(25)
     @test_throws Exception @test_reference "references/wrongfilename.png" imresize(camera, (64,64))
     @test_throws ErrorException @test_reference "references/camera.png" imresize(lena, (64,64))
 end


### PR DESCRIPTION
closes #11 closes #5 

Note: This is a "breaking" changes without deprecations according to https://github.com/Evizero/ReferenceTests.jl/pull/28#issuecomment-535021535

By implementing a simplified version of `psnr` function, the whole dependency on `Images` now reduces to `ImageCore`, which boosts package loading by ~4x. (previously it's about 16.5s, now it's 4s)

In case the default psnr threshold 25 doesn't satisfies all cases, I introduce and export a util `psnr_equality`.

Notes on `Project.toml` changes:
* `ImageCore >= 0.8.1` reexports `FixedPointNumbers` and `ColorTypes`
* `Distances` is used to implement a `psnr` function
* remove >= specifier in [Compat] as comments suggusted