### PR TITLE
promote N0f8 to Float64 before calculate PSNR

### DIFF
--- a/src/equality_metrics.jl
+++ b/src/equality_metrics.jl
@@ -37,4 +37,4 @@ _psnr(ref::AbstractArray{<:AbstractGray}, x::AbstractArray{<:AbstractGray}) =
     _psnr(channelview(ref), channelview(x), 1.0)
 
 _psnr(ref::AbstractArray{<:Real}, x::AbstractArray{<:Real}, peakval::Real) =
-    20log10(peakval) - 10log10(euclidean(ref, x))
+    20log10(peakval) - 10log10(euclidean(float.(ref), float.(x)))


### PR DESCRIPTION
`N0f8` might introduce some roundoff error that surprises users.