### PR TITLE
correct the rendermode for txt images

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReferenceTests"
 uuid = "324d217c-45ce-50fc-942e-d289b448e8cf"
 authors = ["Christof Stocker <stocker.christof@gmail.com>", "Lyndon White <oxinabox@ucc.asn.au>"]
-version = "0.8.3"
+version = "0.8.4"
 
 [deps]
 DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"

--- a/src/render.jl
+++ b/src/render.jl
@@ -57,7 +57,7 @@ default_rendermode(::Type{<:DataFormat}, ::AbstractArray{<:Colorant}) = BeforeAf
 default_rendermode(::Type{DataFormat{:TXT}}, ::Any) = Diff()
 default_rendermode(::Type{DataFormat{:TXT}}, ::AbstractString) = Diff()
 default_rendermode(::Type{DataFormat{:TXT}}, ::Number) = BeforeAfterFull()
-default_rendermode(::Type{DataFormat{:TXT}}, ::AbstractArray{<:Colorant}) = BeforeAfterFull()
+default_rendermode(::Type{DataFormat{:TXT}}, ::AbstractArray{<:Colorant}) = BeforeAfterImage()
 
 # SHA256
 default_rendermode(::Type{DataFormat{:SHA256}}, ::Any) = BeforeAfterFull()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ if isinteractive()
     @info ("In interactive use, one should respond \"n\" when the program"
            * " offers to create or replace files associated with some tests.")
 else
-    @info ("Nine tests should correctly report failure in the transcript"
+    @info ("Ten tests should correctly report failure in the transcript"
            * " (but not the test summary).")
 end
 # check for ambiguities
@@ -77,6 +77,7 @@ end
 
 @testset "images as txt using ImageInTerminal" begin
     #@test_throws MethodError @test_reference "references/fail.txt" rand(2,2)
+    @test_throws ErrorException @test_reference "references/camera_new.txt" camera size=(5,10)
     @test_reference "references/camera.txt" camera size=(5,10)
     @test_reference "references/lena.txt" lena
 end


### PR DESCRIPTION
If we call `@test_reference "references/camera_new.txt" camera size=(5,10)` it would print an "endless" string... It's definitely a bug here.