### PR TITLE
If file does not exist, create it (No Prompt)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReferenceTests"
 uuid = "324d217c-45ce-50fc-942e-d289b448e8cf"
 authors = ["Christof Stocker <stocker.christof@gmail.com>", "Lyndon White <oxinabox@ucc.asn.au>"]
-version = "0.8.4"
+version = "0.9.0"
 
 [deps]
 DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"

--- a/src/test_reference.jl
+++ b/src/test_reference.jl
@@ -114,18 +114,10 @@ function test_reference(
         # TODO: move encoding out from render
         render(rendermode, raw_actual)
 
-        if !isinteractive()
-            error("You need to run the tests interactively with 'include(\"test/runtests.jl\")' to create new reference images")
-        end
-
-        if !input_bool("Create reference file with above content (path: $path)?")
-            @test false
-        else
-            mkpath(dir)
-            savefile(file, actual)
-            @info("Please run the tests again for any changes to take effect")
-        end
-
+        mkpath(dir)
+        savefile(file, actual)
+        
+        @info("Please run the tests again for any changes to take effect")
         return nothing # skip current test case
     end
 

--- a/src/test_reference.jl
+++ b/src/test_reference.jl
@@ -110,13 +110,13 @@ function test_reference(
     actual = _convert(F, raw_actual; kw...)
     # preprocessing when reference file doesn't exists
     if !isfile(path)
-        println("Reference file for \"$filename\" does not exist.")
+        @info("Reference file for \"$filename\" does not exist. It will be created")
         # TODO: move encoding out from render
         render(rendermode, raw_actual)
 
         mkpath(dir)
         savefile(file, actual)
-        
+
         @info("Please run the tests again for any changes to take effect")
         return nothing # skip current test case
     end


### PR DESCRIPTION
This removes the prompt before creating reference files.

I have wanted this for a while, because when creating dozens (or hundreds) of reference files, I don't want to sit there hammering "yes".
This also means if I need to regenerate everything, I can delete my reference folder and rerun my tests.

I tend to do almost all my review of reference files during code-review rather than in the terminal.

I think this is a better behavour, but In theory someone could be relying on this to make sure that files were not created by mistake, e.g. by looking at the filename, not just the content.

So I bumped this as a breaking change, just incase.
Its not really an API change, as much as a UI change.
Maybe I should only do a nonbreaking verion bump?